### PR TITLE
Replace Object w Ref, remove absolute refs

### DIFF
--- a/godot/CombatDemo.tscn
+++ b/godot/CombatDemo.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=19 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://CombatSystem/Background/grasslands.png" type="Texture" id=1]
 [ext_resource path="res://CombatSystem/Battler/Actions/AttackAction.gd" type="Script" id=2]
 [ext_resource path="res://CombatSystem/porcupine.png" type="Texture" id=3]
+[ext_resource path="res://CombatSystem/UserInterface/UISelectBattlerArrow.tscn" type="PackedScene" id=4]
 [ext_resource path="res://CombatSystem/ActiveTurnQueue.gd" type="Script" id=5]
 [ext_resource path="res://CombatSystem/Battler/Characters/Porcupine.tscn" type="PackedScene" id=6]
 [ext_resource path="res://CombatSystem/Battler/Battler.gd" type="Script" id=7]
@@ -14,6 +15,7 @@
 [ext_resource path="res://CombatSystem/Battler/BattlerStats.gd" type="Script" id=13]
 [ext_resource path="res://CombatSystem/UserInterface/UIBattlerHUD/UIBattlerHUDList.tscn" type="PackedScene" id=14]
 [ext_resource path="res://CombatSystem/Battler/AI/BattlerAI.gd" type="Script" id=15]
+[ext_resource path="res://CombatSystem/UserInterface/UIActionMenu/UIActionMenu.tscn" type="PackedScene" id=16]
 
 [sub_resource type="Resource" id=1]
 script = ExtResource( 13 )
@@ -51,6 +53,8 @@ __meta__ = {
 
 [node name="ActiveTurnQueue" type="Node2D" parent="."]
 script = ExtResource( 5 )
+UIActionMenuScene = ExtResource( 16 )
+SelectArrow = ExtResource( 4 )
 
 [node name="Robi" parent="ActiveTurnQueue" instance=ExtResource( 9 )]
 position = Vector2( 1467.32, 725.777 )

--- a/godot/CombatSystem/ActiveTurnQueue.gd
+++ b/godot/CombatSystem/ActiveTurnQueue.gd
@@ -2,8 +2,8 @@ extends Node
 
 signal player_turn_finished
 
-const UIActionMenuScene: PackedScene = preload("res://CombatSystem/UserInterface/UIActionMenu/UIActionMenu.tscn")
-const SelectArrow: PackedScene = preload("res://CombatSystem/UserInterface/UISelectBattlerArrow.tscn")
+export var UIActionMenuScene: PackedScene
+export var SelectArrow: PackedScene
 
 # Allows pausing the Active Time Battle during combat intro or a cut-scene.
 var is_active := true setget set_is_active
@@ -100,10 +100,10 @@ func _player_select_targets_async(_action: Action, opponents: Array) -> Array:
 
 
 func _on_player_turn_finished() -> void:
-	if _queue_player != []:
-		_play_turn(_queue_player.pop_front())
-	else:
+	if _queue_player.empty():
 		_is_player_playing = false
+	else:
+		_play_turn(_queue_player.pop_front())
 
 
 func _on_Battler_ready_to_act(battler: Battler) -> void:

--- a/godot/CombatSystem/Battler/Actions/AttackAction.gd
+++ b/godot/CombatSystem/Battler/Actions/AttackAction.gd
@@ -14,7 +14,8 @@ func _init() -> void:
 # Plays the acting battler's attack animation once for each target. Damages each target when the actor's animation emits the `triggered` signal.
 func _apply_async(actor, targets: Array) -> bool:
 	var anim: BattlerAnim = actor.battler_anim
-	anim.connect("triggered", self, "_on_BattlerAnim_triggered")
+	if not anim.is_connected("triggered", self, "_on_BattlerAnim_triggered"):
+		anim.connect("triggered", self, "_on_BattlerAnim_triggered")
 	for target in targets:
 		hits.append(Hit.new(target, actor.get_damage()))
 		anim.play("attack")

--- a/godot/CombatSystem/Battler/Actions/Hit.gd
+++ b/godot/CombatSystem/Battler/Actions/Hit.gd
@@ -1,7 +1,7 @@
 # Represents a damage-dealing hit to be applied to a target [Battler].
 # Encapsulates calculations for how hits are applied based on their properties.
 class_name Hit
-extends Object
+extends Reference
 
 var damage := 0
 var target: Battler = null

--- a/godot/CombatSystem/Battler/Animation/BattlerAnim.gd
+++ b/godot/CombatSystem/Battler/Animation/BattlerAnim.gd
@@ -31,12 +31,28 @@ func get_anchor_global_position() -> Vector2:
 
 
 func move_forward() -> void:
-	tween.interpolate_property(self, "position", position, position + Vector2.LEFT * scale.x * 40.0, 0.3, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
+	tween.interpolate_property(
+		self,
+		"position",
+		position,
+		position + Vector2.LEFT * scale.x * 40.0,
+		0.3,
+		Tween.TRANS_QUART,
+		Tween.EASE_IN_OUT
+	)
 	tween.start()
 
 
 func move_back() -> void:
-	tween.interpolate_property(self, "position", position, _position_start, 0.3, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
+	tween.interpolate_property(
+		self,
+		"position",
+		position,
+		_position_start,
+		0.3,
+		Tween.TRANS_QUART,
+		Tween.EASE_IN_OUT
+	)
 	tween.start()
 
 

--- a/godot/CombatSystem/Battler/Battler.gd
+++ b/godot/CombatSystem/Battler/Battler.gd
@@ -87,7 +87,8 @@ func set_is_active(value):
 
 
 func set_is_selected(value):
-	assert(is_selectable)
+	if value:
+		assert(is_selectable)
 	is_selected = value
 	if is_selected:
 		battler_anim.move_forward()

--- a/godot/CombatSystem/UserInterface/UIActionMenu/UIActionList.gd
+++ b/godot/CombatSystem/UserInterface/UIActionMenu/UIActionList.gd
@@ -3,7 +3,7 @@ extends VBoxContainer
 
 signal action_selected(action)
 
-const UIActionButton: PackedScene = preload("res://CombatSystem/UserInterface/UIActionMenu/UIActionButton.tscn")
+const UIActionButton: PackedScene = preload("UIActionButton.tscn")
 
 var is_disabled = false setget set_is_disabled
 var buttons := []

--- a/godot/CombatSystem/UserInterface/UIBattlerHUD/UIBattlerHUDList.gd
+++ b/godot/CombatSystem/UserInterface/UIBattlerHUD/UIBattlerHUDList.gd
@@ -1,6 +1,6 @@
 extends VBoxContainer
 
-const UIBattlerHUD: PackedScene = preload("res://CombatSystem/UserInterface/UIBattlerHUD/UIBattlerHUD.tscn")
+const UIBattlerHUD: PackedScene = preload("UIBattlerHUD.tscn")
 
 
 # Arguments:

--- a/godot/CombatSystem/UserInterface/UIBattlerHUD/UIEnergyBar/UIEnergyBar.gd
+++ b/godot/CombatSystem/UserInterface/UIBattlerHUD/UIEnergyBar/UIEnergyBar.gd
@@ -1,7 +1,7 @@
 # Bar representing energy points. Each point is an instance of UIEnergyPoint.
 extends HBoxContainer
 
-const UIEnergyPoint: PackedScene = preload("res://CombatSystem/UserInterface/UIBattlerHUD/UIEnergyBar/UIEnergyPoint.tscn")
+const UIEnergyPoint: PackedScene = preload("UIEnergyPoint.tscn")
 
 var max_value := 0
 var value := 0 setget set_value

--- a/godot/CombatSystem/UserInterface/UISelectBattlerArrow.gd
+++ b/godot/CombatSystem/UserInterface/UISelectBattlerArrow.gd
@@ -73,7 +73,7 @@ func _move_to(target_position: Vector2):
 # Returns null if there is no other target in the direction.
 func _find_closest_target(direction: Vector2) -> Battler:
 	var selected_target: Battler
-	var distance_to_selected: float = 100000.0
+	var distance_to_selected: float = INF
 
 	var candidates := []
 	for battler in _targets:

--- a/godot/CombatSystem/UserInterface/UITurnBar/UIBattlerIcon.gd
+++ b/godot/CombatSystem/UserInterface/UITurnBar/UIBattlerIcon.gd
@@ -6,17 +6,17 @@ extends TextureRect
 
 enum Types { ALLY, PLAYER, ENEMY }
 
+const TYPES := {
+	Types.ALLY: preload("portrait_bg_ally.png"),
+	Types.PLAYER: preload("portrait_bg_player.png"),
+	Types.ENEMY: preload("portrait_bg_enemy.png"),
+}
+
 export var icon: Texture setget set_icon
 
 export (Types) var type: int = Types.ENEMY setget set_type
 
 var position_range := Vector2.ZERO
-
-var _types := {
-	Types.ALLY: load("res://CombatSystem/UserInterface/UITurnBar/portrait_bg_ally.png"),
-	Types.PLAYER: load("res://CombatSystem/UserInterface/UITurnBar/portrait_bg_player.png"),
-	Types.ENEMY: load("res://CombatSystem/UserInterface/UITurnBar/portrait_bg_enemy.png"),
-}
 
 onready var _icon_node := $Icon
 
@@ -34,4 +34,4 @@ func set_icon(value: Texture) -> void:
 
 func set_type(value: int) -> void:
 	type = value
-	texture = _types[type]
+	texture = TYPES[type]

--- a/godot/CombatSystem/UserInterface/UITurnBar/UITurnBar.gd
+++ b/godot/CombatSystem/UserInterface/UITurnBar/UITurnBar.gd
@@ -2,7 +2,7 @@
 # Battlers move along the timeline as their readiness rating updates.
 extends Control
 
-const BattlerIcon := preload("res://CombatSystem/UserInterface/UITurnBar/UIBattlerIcon.tscn")
+const BattlerIcon := preload("UIBattlerIcon.tscn")
 
 var icons := []
 

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -24,7 +24,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://CombatSystem/Battler/Battler.gd"
 }, {
-"base": "Reference",
+"base": "Resource",
 "class": "BattlerAI",
 "language": "GDScript",
 "path": "res://CombatSystem/Battler/AI/BattlerAI.gd"
@@ -49,7 +49,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://CombatSystem/Battler/Actions/EnergyChargeAction.gd"
 }, {
-"base": "Object",
+"base": "Reference",
 "class": "Hit",
 "language": "GDScript",
 "path": "res://CombatSystem/Battler/Actions/Hit.gd"
@@ -104,7 +104,6 @@ gdscript/warnings/return_value_discarded=false
 
 window/size/width=1920
 window/size/height=1080
-window/size/fullscreen=true
 window/size/test_width=960
 window/size/test_height=540
 window/stretch/mode="2d"


### PR DESCRIPTION
The code is solid, unfinished bugs aside. That said, I did go in and replace absolute "res//:" paths with relative or exports, depending. Same reason I gave johnny: can't fix 'em if they move without manual labor.

Hit.gd was also extending Object. Object is not automatically cleaned up in memory without explicitly calling free(). Reference, on the other hand, does clean up when it does out of scope, which is how you were using it, so I changed it to extend Reference.

Otherwise, it's solid and I like it.